### PR TITLE
Vcdparse submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcdparse"]
+	path = vcdparse
+	url = git@github.com:sifive/vcdparse.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vcdparse"]
 	path = vcdparse
 	url = git@github.com:sifive/vcdparse.git
+	branch = mman-kjm

--- a/install.sh
+++ b/install.sh
@@ -109,12 +109,9 @@ then
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         if [[ $(grep -i Microsoft /proc/version) ]]; then
             # WSL Build
-            echo "!!!"
-            echo "!!! VCDPARSE: Waiting for CROSS build support to do Windows..."
-            echo "!!!"
-            # CROSS=i686-w64-mingw32- make clean standalone
-            # echo "Installing vcdParse..."
-            # cp vcdParse.exe ${dev_root_target}/bin
+            CROSS=i686-w64-mingw32- make clean standalone
+            echo "Installing vcdParse..."
+            cp vcdParse.exe ${dev_root_target}/bin
         else
             # Linux build
             make clean standalone python

--- a/install.sh
+++ b/install.sh
@@ -81,10 +81,12 @@ then
     echo "Installing http-server-relay"
 
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        killall -w http-server-relay-linux || true
         if [[ $(grep -i Microsoft /proc/version) ]]; then
+            # WSL Build
             cp http-server-relay-win.exe ${dev_root_target}/bin
         else
+            # Linux build
+            killall -w http-server-relay-linux || true
             cp http-server-relay-linux ${dev_root_target}/bin
         fi
         
@@ -105,10 +107,20 @@ then
     echo "Building vcdParse..."
     cd vcdparse
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # Linux build
-        make clean standalone python
-        echo "Installing vcdParse..."
-        cp vcdParse vcdParser.py _vcdParser.so ${dev_root_target}/bin
+        if [[ $(grep -i Microsoft /proc/version) ]]; then
+            # WSL Build
+            echo "!!!"
+            echo "!!! VCDPARSE: Waiting for CROSS build support to do Windows..."
+            echo "!!!"
+            # CROSS=i686-w64-mingw32- make clean standalone
+            # echo "Installing vcdParse..."
+            # cp vcdParse.exe ${dev_root_target}/bin
+        else
+            # Linux build
+            make clean standalone python
+            echo "Installing vcdParse..."
+            cp vcdParse vcdParser.py _vcdParser.so ${dev_root_target}/bin
+        fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
         make clean standalone python

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,51 @@
 #!/bin/bash
 
+# This script will build and install vcdrom, vcdParse, and http-server-relay into a developement 
+# environment.  For Linux and MacOS you can simply run the script as described below.
+#
+# For Windows you need to run this script under WSL2 Ubuntu.  To make this work you need
+# to install the mingw-w64 build environment once:
+#
+# sudo apt install mingw-w64
+#
+# The script will detect that you are in a WSL environment and build the Windows execuables for vcdParse
+#
+# This script require two environment variables be defined:
+#
+# FS_WS is the path to the workspace you are using for the FS AUT (application under test).
+# FS_ROOTDIR is the path the parent folder of your dev-root/SiFive folder.
+#
+# For instance:
+#
+# WSL2 Ubuntu (you can put this in ~/.bashrc):
+#    FS_WS=/mnt/c/eclipse/eclipse-2022.03-rcp/runtime-freedom-studio
+#    FS_ROOTDIR=/mnt/c/dev-root
+#
+# Ubuntu (you can put this in ~/.bashrc):
+#    export FS_WS=/home/kevinm/sifive/ws-multitap
+#    export FS_ROOTDIR=/home/kevinm/dev-root
+#
+# MacOS (you can put this in ~/.zprofile):
+#    export FS_WS=/Users/kevin/fs-dev-x86
+#    export FS_ROOTDIR=/Users/kevin/dev-root
+#
+# The FS_WS path allows the webapp to be installed to AUT workspace and be used without having to 
+# restart Freedom Studio
+#
+# RUNNING THE SCRIPT
+#
+# If you run the script with no parameters only the vcdrom webapp will be built and installed.  
+# This is great if you are working on webapp code and builds faster than doing everything
+#
+# Options to the script:
+#
+#   -v build and install vcdrom
+#   -s build and install http-server-relay
+#   -p build and install vcdparse
+#   -a build and install everything
+
+
+
 doServer=false
 doParser=false
 doWebapp=false

--- a/install.sh
+++ b/install.sh
@@ -2,17 +2,26 @@
 
 doServer=false
 doParser=false
-doWebapp=true
-while getopts sap flag
+doWebapp=false
+
+# Build vcdom only if no cmd line params are given
+if [ "$#" -eq 0 ]; then
+    doWebapp=true
+fi
+
+while getopts savp flag
 do
     case "${flag}" in
         s) 
             doServer=true ;;
+        v) 
+            doWebapp=true ;;
         p) 
             doParser=true ;;
         a) 
             doServer=true
             doParser=true
+            doWebapp=true
             ;;
     esac
 done


### PR DESCRIPTION
Adding vcdparse as a submodule to vcdrom to support build distribution packages (eventually), and to support building and installing assets into a FS development environment.

Since Brad is currently reworking the build environment for vcdparse to prepare it for integrating into Freedom Tools, this submodule is currently pointing to a branch that allows for building all Windows assets on WSL2.

The install.sh script contains documentation on how to use this in your development environment.

I'm merging this PR immediately.  No need to approve (or reject it).  I'll keep the branch around so you take a look the changes if you are interested in such things.